### PR TITLE
Documentation for Forge client-only events

### DIFF
--- a/src/docs/net/minecraftforge/client/event/ClientChatEvent.dox
+++ b/src/docs/net/minecraftforge/client/event/ClientChatEvent.dox
@@ -1,0 +1,44 @@
+/**
+ * @class net.minecraftforge.client.event.ClientChatEvent
+ *
+ * Fired when the client is about to send a chat message or command to the server.
+ * This can be used to implement client-only commands as chat messages, or intercepting messages for typos.
+ *
+ * This event is \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ * If the event is cancelled, the chat message or command will not be sent to the server.
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ *
+ * @see ForgeEventFactory#onClientSendMessage(String)
+ */
+
+/**
+ * @fn public String ClientChatEvent::getMessage()
+ *
+ * Returns the message that will be sent to the server, if the event is not cancelled.
+ * If the message is blank, then no message will be sent to the server.
+ *
+ * The default value is the value of \link ClientChatEvent#getOriginalMessage()\endlink.
+ *
+ * @return The message that will be sent to the server
+ */
+
+/**
+ * @fn public void ClientChatEvent::setMessage(String message)
+ *
+ * Sets the new message to be sent to the server, if the event is not cancelled.
+ *
+ * If \p message is \c null, then it will be converted to an empty string.
+ * If \p message is empty, then no message will be sent to the server.
+ *
+ * @param message The new message to be sent, can be \c null
+ */
+
+/**
+ * @fn public String ClientChatEvent::getOriginalMessage()
+ *
+ * Returns the original message of the event, before any modifications.
+ *
+ * @return The original message of the event
+ */

--- a/src/docs/net/minecraftforge/client/event/ClientChatReceivedEvent.dox
+++ b/src/docs/net/minecraftforge/client/event/ClientChatReceivedEvent.dox
@@ -1,0 +1,50 @@
+/**
+ * @class net.minecraftforge.client.event.ClientChatReceivedEvent
+ *
+ * Fired when the client is about to send a chat message or command to the server.
+ * This can be used to implement client-only commands as chat messages, or intercepting messages for typos.
+ *
+ * This event is \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ * If the event is cancelled, the chat message or command will not be sent to the server.
+ *
+ * This event is fired on the \link MinecraftForge::EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ *
+ * @see ChatType
+ * @see ForgeEventFactory#onClientChat(ChatType, ITextComponent, UUID)
+ */
+
+/**
+ * @fn public ITextComponent ClientChatReceivedEvent::getMessage()
+ *
+ * Returns the message that will be displayed in the chat message window, if the event is not cancelled.
+ * If the message is blank, then no message will be displayed.
+ *
+ * @return The message that will be displayed in the chat message window
+ */
+
+/**
+ * @fn public void ClientChatReceivedEvent::setMessage(ITextComponent message)
+ *
+ * Sets the new message to be displayed in the chat message window, if the event is not cancelled.
+ *
+ * If \p message is \c null, then no message will be displayed.
+ *
+ * @param message The new message to be displayed, can be \c null
+ */
+
+/**
+ * @fn public ChatType ClientChatReceivedEvent::getType()
+ *
+ * Returns the type of the message, as defined by \link ChatType\endlink.
+ *
+ * @return The type of the message
+ */
+
+/**
+ * @fn public UUID ClientChatReceivedEvent::getSenderUUID()
+ *
+ * Returns the UUID of the sender of the message, or \c null if one is not specified.
+ *
+ * @return The UUID of the message's sender, or \c null
+ */

--- a/src/docs/net/minecraftforge/client/event/ClientPlayerNetworkEvent.dox
+++ b/src/docs/net/minecraftforge/client/event/ClientPlayerNetworkEvent.dox
@@ -1,0 +1,92 @@
+/**
+ * @class net.minecraftforge.client.event.ClientPlayerNetworkEvent
+ * Fired on the client for different connectivity events.
+ * See the various subclasses to listen for specific events.
+ *
+ * @see ClientPlayerNetworkEvent.LoggedInEvent
+ * @see ClientPlayerNetworkEvent.LoggedOutEvent
+ * @see ClientPlayerNetworkEvent.RespawnEvent
+ */
+
+/**
+ * @fn public PlayerController ClientPlayerNetworkEvent::getController()
+ * Returns the \ref PlayerController of the client player, or \c null if it does not exist.
+ *
+ * If \ref ClientPlayerNetworkEvent#getPlayer() returns \c null, then this method also returns \c null.
+ *
+ * @return The client-side player controller, may be \c null
+ */
+
+/**
+ * @fn public ClientPlayerEntity ClientPlayerNetworkEvent::getPlayer()
+ * Returns the client-side player instance, or \c null if it does not exist.
+ *
+ * @return The client player instance, may be \c null
+ */
+
+/**
+ * @fn public NetworkManager ClientPlayerNetworkEvent::getNetworkManager()
+ * Returns the client-side network connection manager, or \c null if it does not exist.
+ *
+ * @return The network connection manager, may be \c null
+ */
+
+/**
+ * @class net.minecraftforge.client.event.ClientPlayerNetworkEvent.LoggedInEvent
+ * Fired when the client player logs in to the server.
+ * When this event is fired, the player should be initialized at that point in time.
+ *
+ * \ref ClientPlayerNetworkEvent#getController(), \ref ClientPlayerNetworkEvent#getPlayer(),
+ * and \ref ClientPlayerNetworkEvent#getNetworkManager() are guaranteed to never return \c null in this event.
+ *
+ * This event is not \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ *
+ * @see ClientHooks#firePlayerLogin(PlayerController, ClientPlayerEntity, NetworkManager)
+ */
+
+/**
+ * @class net.minecraftforge.client.event.ClientPlayerNetworkEvent.LoggedOutEvent
+ * Fired when the player logs out.
+ * This event may also fire when a new integrated server is being created.
+ *
+ * This event is not \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ *
+ * @see ClientHooks#firePlayerLogout(PlayerController, ClientPlayerEntity)
+ */
+
+/**
+ * @class net.minecraftforge.client.event.ClientPlayerNetworkEvent.RespawnEvent
+ * Fired when the player object respawns, such as dimension changes.
+ *
+ * \ref ClientPlayerNetworkEvent.RespawnEvent#getNewPlayer() returns the same player instance as
+ * \ref ClientPlayerNetworkEvent#getPlayer(). \ref ClientPlayerNetworkEvent#getController() ,
+ * \ref ClientPlayerNetworkEvent#getPlayer(), and \ref ClientPlayerNetworkEvent#getNetworkManager()
+ * are guaranteed to never return \c null in this event.
+ *
+ * This event is not \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ *
+ * @see ClientHooks#firePlayerRespawn(PlayerController, ClientPlayerEntity, ClientPlayerEntity, NetworkManager)
+ */
+
+/**
+ * @fn public ClientPlayerEntity ClientPlayerNetworkEvent.RespawnEvent::getOldPlayer()
+ * Returns the old \ref ClientPlayerEntity instance that existed before the respawn.
+ *
+ * @return The previous player instance
+ */
+
+/**
+ * @fn public ClientPlayerEntity ClientPlayerNetworkEvent.RespawnEvent::getNewPlayer()
+ * Returns the new \ref ClientPlayerEntity instance that will replace the old instance, after the respawn event.
+ *
+ * @return The newly created player instance
+ */

--- a/src/docs/net/minecraftforge/client/event/ClientPlayerNetworkEvent.dox
+++ b/src/docs/net/minecraftforge/client/event/ClientPlayerNetworkEvent.dox
@@ -77,16 +77,16 @@
  * @see ClientHooks#firePlayerRespawn(PlayerController, ClientPlayerEntity, ClientPlayerEntity, NetworkManager)
  */
 
-/**
- * @fn public ClientPlayerEntity ClientPlayerNetworkEvent.RespawnEvent::getOldPlayer()
- * Returns the old \ref ClientPlayerEntity instance that existed before the respawn.
- *
- * @return The previous player instance
- */
+    /**
+     * @fn public ClientPlayerEntity RespawnEvent::getOldPlayer()
+     * Returns the old \ref ClientPlayerEntity instance that existed before the respawn.
+     *
+     * @return The previous player instance
+     */
 
-/**
- * @fn public ClientPlayerEntity ClientPlayerNetworkEvent.RespawnEvent::getNewPlayer()
- * Returns the new \ref ClientPlayerEntity instance that will replace the old instance, after the respawn event.
- *
- * @return The newly created player instance
- */
+    /**
+     * @fn public ClientPlayerEntity RespawnEvent::getNewPlayer()
+     * Returns the new \ref ClientPlayerEntity instance that will replace the old instance, after the respawn event.
+     *
+     * @return The newly created player instance
+     */

--- a/src/docs/net/minecraftforge/client/event/ColorHandlerEvent.dox
+++ b/src/docs/net/minecraftforge/client/event/ColorHandlerEvent.dox
@@ -1,0 +1,61 @@
+/**
+ * @class net.minecraftforge.client.event.ColorHandlerEvent
+ * Fired for registering block and item color handlers at the appropriate time.
+ * See the two subclasses for registering blocks or items color handlers.
+ *
+ * @see ColorHandlerEvent.Block
+ * @see ColorHandlerEvent.Item
+ */
+
+/**
+ * @class net.minecraftforge.client.event.ColorHandlerEvent.Block
+ * Fired for registering block colors handlers.
+ *
+ * This event is not \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ *
+ * This event is fired on the \link FMLJavaModLoadingContext#getModEventBus() mod-specific event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ *
+ * @see ForgeHooksClient#onBlockColorsInit(BlockColors)
+ */
+
+/**
+ * @fn public BlockColors ColorHandlerEvent.Block::getBlockColors()
+ * Returns an instance of \ref BlockColors, for registering block color providers (\ref IBlockColor).
+ *
+ * @return an instance of the block colors
+ * @see BlockColors#register(IBlockColor, net.minecraft.block.Block...)
+ */
+
+/**
+ * @class net.minecraftforge.client.event.ColorHandlerEvent.Item
+ * Fired for registering item colors handlers.
+ *
+ * The block colors should only be used for referencing or delegating item colors to their respective block colors.
+ * Use \ref ColorHandlerEvent.Block for registering your block color handlers.
+ *
+ * This event is not \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ *
+ * This event is fired on the \link FMLJavaModLoadingContext#getModEventBus() mod-specific event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ *
+ * @see ForgeHooksClient#onItemColorsInit(ItemColors, BlockColors)
+ */
+
+/**
+ * @fn public ItemColors ColorHandlerEvent.Item::getItemColors()
+ * Returns an instance of \ref ItemColors, for registering item color providers (\ref IItemColor).
+ *
+ * @return an instance of the item colors
+ * @see ItemColors#register(IItemColor, IItemProvider...)
+ */
+
+/**
+ * @fn public BlockColors ColorHandlerEvent.Item::getBlockColors()
+ * Returns an instance of \ref BlockColors, for reference and/or delegation.
+ *
+ * This should only be used for reference or delegation to respective block colors.
+ * Use \ref ColorHandlerEvent.Block for registering your block color handlers.
+ *
+ * @return an instance of the block colors
+ */

--- a/src/docs/net/minecraftforge/client/event/ColorHandlerEvent.dox
+++ b/src/docs/net/minecraftforge/client/event/ColorHandlerEvent.dox
@@ -20,7 +20,7 @@
  */
 
 /**
- * @fn public BlockColors ColorHandlerEvent.Block::getBlockColors()
+ * @fn public BlockColors Block::getBlockColors()
  * Returns an instance of \ref BlockColors, for registering block color providers (\ref IBlockColor).
  *
  * @return an instance of the block colors
@@ -43,7 +43,7 @@
  */
 
 /**
- * @fn public ItemColors ColorHandlerEvent.Item::getItemColors()
+ * @fn public ItemColors Item::getItemColors()
  * Returns an instance of \ref ItemColors, for registering item color providers (\ref IItemColor).
  *
  * @return an instance of the item colors
@@ -51,7 +51,7 @@
  */
 
 /**
- * @fn public BlockColors ColorHandlerEvent.Item::getBlockColors()
+ * @fn public BlockColors Item::getBlockColors()
  * Returns an instance of \ref BlockColors, for reference and/or delegation.
  *
  * This should only be used for reference or delegation to respective block colors.

--- a/src/docs/net/minecraftforge/client/event/DrawHighlightEvent.dox
+++ b/src/docs/net/minecraftforge/client/event/DrawHighlightEvent.dox
@@ -1,0 +1,104 @@
+/**
+ * @class net.minecraftforge.client.event.DrawHighlightEvent
+ *
+ * Fired before a selection highlight is rendered.
+ * See the two subclasses to listen for blocks or entities.
+ *
+ * @see DrawHighlightEvent.HighlightBlock
+ * @see DrawHighlightEvent.HighlightEntity
+ * @see ForgeHooksClient#onDrawBlockHighlight(WorldRenderer, ActiveRenderInfo, RayTraceResult, float, MatrixStack, IRenderTypeBuffer)
+ * @todo This event will be renamed to DrawSelectionEvent
+ */
+
+/**
+ * @fn public WorldRenderer getContext()
+ *
+ * Returns the \ref WorldRenderer.
+ *
+ * @return The world renderer
+ */
+
+/**
+ * @fn public ActiveRenderInfo getInfo()
+ *
+ * Returns the \ref ActiveRenderInfo containing the information for the current rendering context.
+ *
+ * @return The active render information
+ */
+
+/**
+ * @fn public RayTraceResult getTarget()
+ *
+ * Returns the \ref RayTraceResult, representing the object at the position of the player's mouse.
+ * The subclasses of this event override this method to return a more specific subclass of \ref RayTraceResult, such as
+ * \ref BlockRayTraceResult.
+ *
+ * @return The target of the highlight
+ * @see HighlightBlock#getTarget()
+ * @see HighlightEntity#getTarget()
+ */
+
+/**
+ * @fn public float getPartialTicks()
+ *
+ * Returns the partial amount of ticks between the last and next render tick.
+ * This will be in the range of <tt>0.0-1.0</tt>.
+ *
+ * @return The amount of partial ticks
+ */
+
+/**
+ * @fn public MatrixStack getMatrix()
+ *
+ * Returns the \ref MatrixStack used for transformations, rotations, and scaling in rendering.
+ *
+ * @return The matrix stack used for rendering
+ */
+
+/**
+ * @fn public IRenderTypeBuffer getBuffers()
+ *
+ * Returns the \ref IRenderTypeBuffer currently being used for rendering.
+ *
+ * @return The rendering buffers
+ */
+
+/**
+ * @class net.minecraftforge.client.event.DrawHighlightEvent.HighlightBlock
+ *
+ * Fired before a block's selection highlight is rendered.
+ *
+ * This event is \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ * If the event is cancelled, then the block selection highlight will not be rendered.
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ */
+
+    /**
+     * @fn public BlockRayTraceResult HighlightBlock::getTarget()
+     *
+     * Returns the \ref BlockRayTraceResult, representing the block at the position of the player's mouse.
+     *
+     * @return The block target of the highlight
+     */
+
+/**
+ * @class net.minecraftforge.client.event.DrawHighlightEvent.HighlightEntity
+ *
+ * Fired before a block's selection highlight is rendered.
+ *
+ * This event is \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ * Cancelling this event has no effect.
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ */
+
+    /**
+     * @fn public EntityRayTraceResult HighlightEntity::getTarget()
+     *
+     * Returns the \ref EntityRayTraceResult, representing the entity at the position of the player's mouse.
+     *
+     * @return The entity target of the highlight
+     */

--- a/src/docs/net/minecraftforge/client/event/FOVUpdateEvent.dox
+++ b/src/docs/net/minecraftforge/client/event/FOVUpdateEvent.dox
@@ -1,0 +1,47 @@
+/**
+ * @class net.minecraftforge.client.event.FOVUpdateEvent
+ *
+ * Fired after the FOV (field of vision) modifier for the player is calculated.
+ * This can be used to modify the FOV before the e.g. FOV settings are applied.
+ *
+ * This event is not \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ *
+ * @see ForgeHooksClient#getOffsetFOV(PlayerEntity, float)
+ * @see EntityViewRenderEvent.FOVModifier
+ * @author MachineMuse
+ */
+
+/**
+ * @fn public PlayerEntity FOVUpdateEvent::getEntity()
+ *
+ * Returns the \ref PlayerEntity affected by this event.
+ *
+ * @return the player entity
+ */
+
+/**
+ * @fn public float FOVUpdateEvent::getFov()
+ *
+ * Returns the original, unmodified FOV (field of vision) of the player.
+ *
+ * @return the original FOV of the player
+ */
+
+/**
+ * @fn public float FOVUpdateEvent::getNewfov()
+ *
+ * Returns the current FOV (field of vision) that will be applied to the player.
+ *
+ * @return the current FOV of the player
+ */
+
+/**
+ * @fn public void FOVUpdateEvent::setNewfov(float newfov)
+ *
+ * Sets the new FOV (field of vision) that will be applied to the player.
+ *
+ * @param newfov the new FOV (field of vision)
+ */

--- a/src/docs/net/minecraftforge/client/event/GuiContainerEvent.dox
+++ b/src/docs/net/minecraftforge/client/event/GuiContainerEvent.dox
@@ -1,0 +1,95 @@
+/**
+ * @class net.minecraftforge.client.event.GuiContainerEvent
+ *
+ * Fired for hooking into \ref ContainerScreen rendering.
+ * See the two subclasses to listen for foreground or background rendering.
+ *
+ * These events are fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ *
+ * @see GuiContainerEvent.DrawForeground
+ * @see GuiContainerEvent.DrawBackground
+ */
+
+/**
+ * @fn public ContainerScreen<?> GuiContainerEvent::getGuiContainer()
+ *
+ * Returns the \ref ContainerScreen of this event.
+ *
+ * @return The container's screen
+ */
+
+/**
+ * @class net.minecraftforge.client.event.GuiContainerEvent.DrawForeground
+ *
+ * Fired <em>after</em> the container screen's <b>foreground</b> layer and elements are drawn, but
+ * before rendering the tooltips and the item stack being dragged by the player.
+ *
+ * This can be used for rendering elements that must be above other screen elements, but
+ * below tooltips and the dragged stack, such as slot or item stack specific overlays.
+ *
+ * This event is not \link Cancelable cancelable\endlink, and does not \link HasResult have a result\endlink
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ */
+
+    /**
+     * @fn public MatrixStack DrawForeground::getMatrixStack()
+     *
+     * Returns the \ref MatrixStack used for transformations, rotations, and scaling in rendering.
+     *
+     * @return The matrix stack used for rendering
+     */
+
+    /**
+     * @fn public int DrawForeground::getMouseX()
+     *
+     * Returns the X coordinate of the mouse pointer, relative to the \link MainWindow main window\endlink of the game.
+     *
+     * @return The X coordinate of the mouse pointer
+     */
+
+    /**
+     * @fn public int DrawForeground::getMouseY()
+     *
+     * Returns the Y coordinate of the mouse pointer, relative to the \link MainWindow main window\endlink of the game.
+     *
+     * @return The Y coordinate of the mouse pointer
+     */
+
+/**
+ * @class net.minecraftforge.client.event.GuiContainerEvent.DrawBackground
+ *
+ * Fired <em>after</em> the container screen's <b>background</b> layer and elements are drawn.
+ * This can be used for rendering new background elements.
+ *
+ * This event is not \link Cancelable cancelable\endlink, and does not \link HasResult have a result\endlink.
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ */
+
+    /**
+     * @fn public MatrixStack DrawBackground::getMatrixStack()
+     *
+     * Returns the \ref MatrixStack used for transformations, rotations, and scaling in rendering.
+     *
+     * @return The matrix stack used for rendering
+     */
+
+    /**
+     * @fn public int DrawBackground::getMouseX()
+     *
+     * Returns the X coordinate of the mouse pointer, relative to the \link MainWindow main window\endlink of the game.
+     *
+     * @return The X coordinate of the mouse pointer
+     */
+
+    /**
+     * @fn public int DrawBackground::getMouseY()
+     *
+     * Returns the Y coordinate of the mouse pointer, relative to the \link MainWindow main window\endlink of the game.
+     *
+     * @return The Y coordinate of the mouse pointer
+     */

--- a/src/docs/net/minecraftforge/client/event/GuiOpenEvent.dox
+++ b/src/docs/net/minecraftforge/client/event/GuiOpenEvent.dox
@@ -1,0 +1,31 @@
+/**
+ * @class net.minecraftforge.client.event.GuiOpenEvent
+ * Fired before any \ref Screen will be opened, for changing it or preventing it from being opened.
+ *
+ * This event is \link Cancelable cancelable\endlink, and does not \link HasResult have a result\endlink.
+ * If this event is cancelled, then the \ref Screen shall be prevented from opening and the previous screen shall remain.
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ *
+ * @see Minecraft#displayGuiScreen(Screen)
+ * @author jk-5
+ */
+
+/**
+ * @fn public Screen GuiOpenEvent::getGui()
+ *
+ * Returns the screen that will be opened, after the event fires and is not cancelled.
+ * If this value is \c null, then the previous screen will be closed and no new screen shall be opened.
+ *
+ * @return The screen that will be opened, may be \c null
+ */
+
+/**
+ * @fn public void GuiOpenEvent::setGui(Screen gui)
+ *
+ * Sets the new \ref Screen to be opened, if the event is not cancelled.
+ * If \p gui is \c null, then the previous screen will be closed and no new screen shall be opened.
+ *
+ * @param gui The new screen to open instead, can be \c null
+ */

--- a/src/docs/net/minecraftforge/client/event/GuiScreenEvent.dox
+++ b/src/docs/net/minecraftforge/client/event/GuiScreenEvent.dox
@@ -123,6 +123,7 @@
      * @fn public float DrawScreenEvent::getRenderPartialTicks()
      *
      * Returns the partial amount of ticks between the last and next render tick.
+     * This will be in the range of <tt>0.0-1.0</tt>.
      *
      * @return The amount of partial render ticks
      */

--- a/src/docs/net/minecraftforge/client/event/GuiScreenEvent.dox
+++ b/src/docs/net/minecraftforge/client/event/GuiScreenEvent.dox
@@ -1,0 +1,631 @@
+/**
+ * @class net.minecraftforge.client.event.GuiScreenEvent
+ *
+ * Fired on different events/actions when a \ref Screen is active and visible.
+ * See the various subclasses for listening to different events.
+ *
+ * These events are fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ *
+ * <b>This classed is annotated with <tt>\link OnlyIn \@OnlyIn\endlink(\link Dist#CLIENT Dist.CLIENT\endlink)</tt>.</b>
+ *
+ * @see GuiScreenEvent.InitGuiEvent
+ * @see GuiScreenEvent.DrawScreenEvent
+ * @see GuiScreenEvent.BackgroundDrawnEvent
+ * @see GuiScreenEvent.PotionShiftEvent
+ * @see GuiScreenEvent.MouseInputEvent
+ * @see GuiScreenEvent.KeyboardKeyEvent
+ * @author bspkrs
+ */
+
+/**
+ * @fn public Screen GuiScreenEvent::getGui()
+ *
+ * Returns the \ref Screen of this event.
+ *
+ * @return The screen
+ */
+
+/**
+ * @class net.minecraftforge.client.event.GuiScreenEvent.InitGuiEvent
+ *
+ * Fired when a \ref Screen is being initialized.
+ * See the two subclasses for listening before and after the initialization.
+ *
+ * @see InitGuiEvent.Pre
+ * @see InitGuiEvent.Post
+ */
+
+    /**
+     * @fn public List<Widget> InitGuiEvent::getWidgetList()
+     *
+     * Returns an unmodifiable view of the list of \link Widget Widgets\endlink on the screen.
+     *
+     * @return An unmodifiable view of the list of widgets
+     */
+
+    /**
+     * @fn public void InitGuiEvent::addWidget(Widget button)
+     *
+     * Adds the given \ref Widget to the screen.
+     *
+     * @param button The widget to add
+     */
+
+    /**
+     * @fn public void InitGuiEvent::removeWidget(Widget button)
+     *
+     * Removes the given \ref Widget from the screen.
+     *
+     * @param button The widget to remove
+     */
+
+    /**
+     * @class net.minecraftforge.client.event.GuiScreenEvent.InitGuiEvent.Pre
+     *
+     * Fired <b>before</b> the screen's overridable initialization method is fired.
+     *
+     * This event is \link Cancelable cancelable\endlink, and does not \link HasResult have a result\endlink.
+     * If the event is cancelled, the initialization method will not be called, 
+     * and the widgets and children lists will not be cleared.
+     *
+     * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+     * only on the \link LogicalSide#CLIENT logical client\endlink.
+     */
+
+    /**
+     * @class net.minecraftforge.client.event.GuiScreenEvent.InitGuiEvent.Post
+     *
+     * Fired <b>after</b> the screen's overridable initialization method is called.
+     *
+     * This event is not \link Cancelable cancelable\endlink, and does not \link HasResult have a result\endlink.
+     *
+     * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+     * only on the \link LogicalSide#CLIENT logical client\endlink.
+     */
+
+/**
+ * @class net.minecraftforge.client.event.GuiScreenEvent.DrawScreenEvent
+ *
+ * Fired when a \ref Screen is being drawn.
+ * See the two subclasses for listening before and after drawing.
+ *
+ * @see DrawScreenEvent.Pre
+ * @see DrawScreenEvent.Post
+ * @see ForgeHooksClient#drawScreen(Screen, MatrixStack, int, int, float)
+ */
+
+    /**
+     * @fn public MatrixStack DrawScreenEvent::getMatrixStack()
+     *
+     * Returns the \ref MatrixStack used for transformations, rotations, and scaling in rendering.
+     *
+     * @return The matrix stack used for rendering
+     */
+
+    /**
+     * @fn public int DrawScreenEvent::getMouseX()
+     *
+     * Returns the X coordinate of the mouse pointer, relative to the \link MainWindow main window\endlink of the game.
+     *
+     * @return The X coordinate of the mouse pointer
+     */
+
+    /**
+     * @fn public int DrawScreenEvent::getMouseY()
+     *
+     * Returns the Y coordinate of the mouse pointer, relative to the \link MainWindow main window\endlink of the game.
+     *
+     * @return The Y coordinate of the mouse pointer
+     */
+
+    /**
+     * @fn public float DrawScreenEvent::getRenderPartialTicks()
+     *
+     * Returns the partial amount of ticks between the last and next render tick.
+     *
+     * @return The amount of partial render ticks
+     */
+
+    /**
+     * @class net.minecraftforge.client.event.GuiScreenEvent.DrawScreenEvent.Pre
+     *
+     * Fired <b>before</b> the \ref Screen is drawn.
+     *
+     * This event is \link Cancelable cancelable\endlink, and does not \link HasResult have a result\endlink.
+     * If the event is cancelled, the screen will not be drawn.
+     *
+     * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+     * only on the \link LogicalSide#CLIENT logical client\endlink.
+     */
+
+    /**
+     * @class net.minecraftforge.client.event.GuiScreenEvent.DrawScreenEvent.Post
+     *
+     * Fired <b>after</b> the \ref Screen is drawn.
+     *
+     * This event is not \link Cancelable cancelable\endlink, and does not \link HasResult have a result\endlink.
+     *
+     * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+     * only on the \link LogicalSide#CLIENT logical client\endlink.
+     */
+
+/**
+ * @class net.minecraftforge.client.event.GuiScreenEvent.BackgroundDrawnEvent
+ *
+ * Fired directly after the background of the \ref Screen is drawn.
+ * Can be used for drawing above the background but below the tooltips.
+ *
+ * This event is not \link Cancelable cancelable\endlink, and does not \link HasResult have a result\endlink.
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ */
+
+    /**
+     * @fn public MatrixStack BackgroundDrawnEvent::getMatrixStack()
+     *
+     * Returns the \ref MatrixStack used for transformations, rotations, and scaling in rendering.
+     *
+     * @return The matrix stack used for rendering
+     */
+
+/**
+ * @class net.minecraftforge.client.event.GuiScreenEvent.PotionShiftEvent
+ *
+ * Fired when there are potion effects to be rendered and the \ref Screen is being shifted.
+ *
+ * This event is \link Cancelable cancelable\endlink, and does not \link HasResult have a result\endlink.
+ * If the event is cancelled, the screen will be prevented from shifting.
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ */
+
+/**
+ * @class net.minecraftforge.client.event.GuiScreenEvent.MouseInputEvent
+ *
+ * Fired whenever an action is performed by the mouse.
+ * See the various subclasses to listen for different actions.
+ *
+ * @see GuiScreenEvent.MouseClickedEvent
+ * @see GuiScreenEvent.MouseReleasedEvent
+ * @see GuiScreenEvent.MouseDragEvent
+ * @see GuiScreenEvent.MouseScrollEvent
+ */
+
+    /**
+     * @fn public double MouseInputEvent::getMouseX()
+     *
+     * Returns the X coordinate of the mouse pointer, relative to the \link MainWindow main window\endlink of the game.
+     *
+     * @return The X position of the mouse cursor
+     */
+
+    /**
+     * @fn public double MouseInputEvent::getMouseY()
+     *
+     * Returns the X coordinate of the mouse pointer, relative to the \link MainWindow main window\endlink of the game.
+     *
+     * @return The Y position of the mouse cursor
+     */
+
+/**
+ * @class net.minecraftforge.client.event.GuiScreenEvent.MouseClickedEvent
+ *
+ * Fired when a mouse button is clicked.
+ * See the two subclasses for listening before and after the normal handling.
+ *
+ * @see MouseClickedEvent.Pre
+ * @see MouseClickedEvent.Post
+ */
+
+    /**
+     * @fn public int MouseClickedEvent::getButton()
+     *
+     * Returns the GLFW key code of the clicked mouse button.
+     *
+     * @return The key code of the clicked mouse button
+     *
+     * @see GLFW#GLFW_MOUSE_BUTTON_LEFT
+     * @see GLFW#GLFW_MOUSE_BUTTON_RIGHT
+     * @see GLFW#GLFW_MOUSE_BUTTON_MIDDLE
+     * @see GLFW key constants starting with 'GLFW_MOUSE_BUTTON_'
+     * @see <a href="http://www.glfw.org/docs/latest/input.html#input_mouse_button" target="_top">the online GLFW documentation</a>
+     */
+
+    /**
+     * @class net.minecraftforge.client.event.GuiScreenEvent.MouseClickedEvent.Pre
+     *
+     * Fired <b>before</b> the mouse click is handled by the screen.
+     *
+     * This event is \link Cancelable cancelable\endlink, and does not \link HasResult have a result\endlink.
+     * If the event is cancelled, the screen's mouse click handler will be bypassed
+     * and the corresponding \ref MouseClickedEvent.Post will not be fired.
+     *
+     * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+     * only on the \link LogicalSide#CLIENT logical client\endlink.
+     *
+     * @see ForgeHooksClient#onGuiMouseClickedPre(Screen, double, double, int)
+     */
+
+    /**
+     * @class net.minecraftforge.client.event.GuiScreenEvent.MouseClickedEvent.Post
+     *
+     * Fired <b>after</b> the mouse click is handled, if not handled by the screen
+     * and the corresponding \ref MouseClickedEvent.Pre is not cancelled.
+     *
+     * This event is \link Cancelable cancelable\endlink, and does not \link HasResult have a result\endlink.
+     * If the event is cancelled, the mouse click will be set as handled.
+     *
+     * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+     * only on the \link LogicalSide#CLIENT logical client\endlink.
+     *
+     * @see ForgeHooksClient#onGuiMouseClickedPost(Screen, double, double, int)
+     */
+
+/**
+ * @class net.minecraftforge.client.event.GuiScreenEvent.MouseReleasedEvent
+ *
+ * Fired when a mouse button is released.
+ * See the two subclasses for listening before and after the normal handling.
+ *
+ * @see MouseReleasedEvent.Pre
+ * @see MouseReleasedEvent.Post
+ */
+
+    /**
+     * @fn public int MouseReleasedEvent::getButton()
+     *
+     * Returns the GLFW key code of the released mouse button.
+     *
+     * @return The key code of the released mouse button
+     *
+     * @see GLFW#GLFW_MOUSE_BUTTON_LEFT
+     * @see GLFW#GLFW_MOUSE_BUTTON_RIGHT
+     * @see GLFW#GLFW_MOUSE_BUTTON_MIDDLE
+     * @see GLFW key constants starting with 'GLFW_MOUSE_BUTTON_'
+     * @see <a href="http://www.glfw.org/docs/latest/input.html#input_mouse_button" target="_top">the online GLFW documentation</a>
+     */
+
+    /**
+     * @class net.minecraftforge.client.event.GuiScreenEvent.MouseReleasedEvent.Pre
+     *
+     * Fired <b>before</b> the mouse release is handled by the screen.
+     *
+     * This event is \link Cancelable cancelable\endlink, and does not \link HasResult have a result\endlink.
+     * If the event is cancelled, the screen's mouse release handler will be bypassed
+     * and the corresponding \ref MouseReleasedEvent.Post will not be fired.
+     *
+     * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+     * only on the \link LogicalSide#CLIENT logical client\endlink.
+     *
+     * @see ForgeHooksClient#onGuiMouseReleasedPre(Screen, double, double, int)
+     */
+
+    /**
+     * @class net.minecraftforge.client.event.GuiScreenEvent.MouseReleasedEvent.Post
+     *
+     * Fired <b>after</b> the mouse release is handled, if not handled by the screen
+     * and the corresponding \ref MouseReleasedEvent.Pre is not cancelled.
+     *
+     * This event is \link Cancelable cancelable\endlink, and does not \link HasResult have a result\endlink.
+     * If the event is cancelled, the mouse release will be set as handled.
+     *
+     * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+     * only on the \link LogicalSide#CLIENT logical client\endlink.
+     *
+     * @see ForgeHooksClient#onGuiMouseReleasedPost(Screen, double, double, int)
+     */
+
+/**
+ * @class net.minecraftforge.client.event.GuiScreenEvent.MouseDragEvent
+ *
+ * Fired when the mouse was dragged while a button is being held down.
+ * See the two subclasses for listening before and after the normal handling.
+ *
+ * @see MouseDragEvent.Pre
+ * @see MouseDragEvent.Post
+ */
+
+    /**
+     * @fn public int MouseDragEvent::getMouseButton()
+     *
+     * Returns the GLFW key code of the dragged mouse button.
+     *
+     * @return The key code of the mouse button that was dragged
+     *
+     * @see GLFW#GLFW_MOUSE_BUTTON_LEFT
+     * @see GLFW#GLFW_MOUSE_BUTTON_RIGHT
+     * @see GLFW#GLFW_MOUSE_BUTTON_MIDDLE
+     * @see GLFW key constants starting with 'GLFW_MOUSE_BUTTON_'
+     * @see <a href="http://www.glfw.org/docs/latest/input.html#input_mouse_button" target="_top">the online GLFW documentation</a>
+     */
+
+    /**
+     * @fn public double MouseDragEvent::getDragX()
+     *
+     * The amount of offset between the new position against the old position of the mouse along the X (horizontal) axis.
+     *
+     * @return The amount of mouse drag along the X axis
+     */
+
+    /**
+     * @fn public double MouseDragEvent::getDragY()
+     *
+     * The amount of offset between the new position against the old position of the mouse along the Y (vertical) axis.
+     *
+     * @return The amount of mouse drag along the Y axis
+     */
+
+    /**
+     * @class net.minecraftforge.client.event.GuiScreenEvent.MouseDragEvent.Pre
+     *
+     * Fired <b>before</b> the mouse drag is handled by the screen.
+     *
+     * This event is \link Cancelable cancelable\endlink, and does not \link HasResult have a result\endlink.
+     * If the event is cancelled, the screen's mouse drag handler will be bypassed
+     * and the corresponding \ref MouseDragEvent.Post will not be fired.
+     *
+     * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+     * only on the \link LogicalSide#CLIENT logical client\endlink.
+     *
+     * @see ForgeHooksClient#onGuiMouseDragPre(Screen, double, double, int, double, double)
+     */
+
+    /**
+     * @class net.minecraftforge.client.event.GuiScreenEvent.MouseDragEvent.Post
+     *
+     * Fired <b>after</b> the mouse drag is handled, if not handled by the screen
+     * and the corresponding \ref MouseDragEvent.Pre is not cancelled.
+     *
+     * This event is \link Cancelable cancelable\endlink, and does not \link HasResult have a result\endlink.
+     * If the event is cancelled, the mouse drag will be set as handled.
+     *
+     * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+     * only on the \link LogicalSide#CLIENT logical client\endlink.
+     *
+     * @see ForgeHooksClient#onGuiMouseDragPost(Screen, double, double, int, double, double)
+     */
+
+/**
+ * @class net.minecraftforge.client.event.GuiScreenEvent.MouseScrollEvent
+ *
+ * Fired when the mouse was dragged while a button is being held down.
+ * See the two subclasses for listening before and after the normal handling.
+ *
+ * @see MouseScrollEvent.Pre
+ * @see MouseScrollEvent.Post
+ */
+
+    /**
+     * @fn public double MouseScrollEvent::getScrollDelta()
+     *
+     * Returns the amount of change or <em>delta</em> of the mouse scroll wheel.
+     *
+     * @return The delta of the mouse scroll
+     */
+
+    /**
+     * @class net.minecraftforge.client.event.GuiScreenEvent.MouseScrollEvent.Pre
+     *
+     * Fired <b>before</b> the mouse scroll is handled by the screen.
+     *
+     * This event is \link Cancelable cancelable\endlink, and does not \link HasResult have a result\endlink.
+     * If the event is cancelled, the screen's mouse scroll handler will be bypassed
+     * and the corresponding \ref MouseScrollEvent.Post will not be fired.
+     *
+     * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+     * only on the \link LogicalSide#CLIENT logical client\endlink.
+     *
+     * @see ForgeHooksClient#onGuiMouseScrollPre(MouseHelper, Screen, double)
+     */
+
+    /**
+     * @class net.minecraftforge.client.event.GuiScreenEvent.MouseScrollEvent.Post
+     *
+     * Fired <b>after</b> the mouse scroll is handled, if not handled by the screen
+     * and the corresponding \ref MouseScrollEvent.Pre is not cancelled.
+     *
+     * This event is \link Cancelable cancelable\endlink, and does not \link HasResult have a result\endlink.
+     * If the event is cancelled, the mouse scroll will be set as handled.
+     *
+     * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+     * only on the \link LogicalSide#CLIENT logical client\endlink.
+     *
+     * @see ForgeHooksClient#onGuiMouseScrollPost(MouseHelper, Screen, double)
+     */
+
+/**
+ * @class net.minecraftforge.client.event.GuiScreenEvent.KeyboardKeyEvent
+ *
+ * Fired whenever a keyboard key is pressed or released.
+ * See the various subclasses to listen for key pressing or releasing.
+ *
+ * @see GuiScreenEvent.KeyboardKeyPressedEvent
+ * @see GuiScreenEvent.KeyboardKeyReleasedEvent
+ * @see InputMappings#getInputByCode(int, int)
+ * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_key" target="_top">the online GLFW documentation</a>
+ */
+
+    /**
+     * @fn public int KeyboardKeyEvent::getKeyCode()
+     *
+     * Returns the GLFW (platform-agnostic) key code of the keyboard key.
+     *
+     * @return The GLFW (platform-agnostic) key code
+     *
+     * @see GLFW key constants starting with 'GLFW_KEY_'
+     * @see <a href="https://www.glfw.org/docs/latest/group__keys.html" target="_top">the online GLFW documentation</a>
+     */
+
+    /**
+     * @fn public int KeyboardKeyEvent::getScanCode()
+     *
+     * Returns the platform-specific scan code of the keyboard key.
+     *
+     * The scan code is unique for every key, regardless of whether it has a key code.
+     * Scan codes are platform-specific but consistent over time, so keys will have different scan codes depending
+     * on the platform but they are safe to save to disk as custom key bindings.
+     *
+     * @return The platform-specific scan code
+     */
+
+    /**
+     * @fn public int KeyboardKeyEvent::getModifiers()
+     *
+     * Returns a bit field number representing the currently active modifier keys.
+     *
+     * @return A bit field representing the active modifier keys
+     *
+     * @see GLFW#GLFW_MOD_SHIFT SHIFT modifier key bit
+     * @see GLFW#GLFW_MOD_CONTROL CTRL modifier key bit
+     * @see GLFW#GLFW_MOD_ALT ALT modifier key bit
+     * @see GLFW#GLFW_MOD_SUPER SUPER modifier key bit
+     * @see GLFW#GLFW_KEY_CAPS_LOCK CAPS LOCK modifier key bit
+     * @see GLFW#GLFW_KEY_NUM_LOCK NUM LOCK modifier key bit
+     * @see <a href="https://www.glfw.org/docs/latest/group__mods.html" target="_top">the online GLFW documentation</a>
+     */
+
+/**
+ * @class net.minecraftforge.client.event.GuiScreenEvent.KeyboardKeyPressedEvent
+ *
+ * Fired when a keyboard key is pressed.
+ * See the two subclasses for listening before and after the normal handling.
+ *
+ * @see KeyboardKeyPressedEvent.Pre
+ * @see KeyboardKeyPressedEvent.Post
+ */
+
+    /**
+     * @class net.minecraftforge.client.event.GuiScreenEvent.KeyboardKeyPressedEvent.Pre
+     *
+     * Fired <b>before</b> the key press is handled by the screen.
+     *
+     * This event is \link Cancelable cancelable\endlink and does not \link HasResult have a result\endlink.
+     * If the event is cancelled, the screen's key press handler will be bypassed
+     * and the corresponding \ref KeyboardKeyPressedEvent.Post will not be fired.
+     *
+     * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+     * only on the \link LogicalSide#CLIENT logical client\endlink.
+     *
+     * @see ForgeHooksClient#onGuiKeyPressedPre(Screen, int, int, int)
+     */
+
+    /**
+     * @class net.minecraftforge.client.event.GuiScreenEvent.KeyboardKeyPressedEvent.Post
+     *
+     * Fired <b>after</b> the key press is handled, if not handled by the screen
+     * and the corresponding \ref KeyboardKeyPressedEvent.Pre is not cancelled.
+     *
+     * This event is \link Cancelable cancelable\endlink, and does not \link HasResult have a result\endlink.
+     * If the event is cancelled, the key press will be set as handled.
+     *
+     * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+     * only on the \link LogicalSide#CLIENT logical client\endlink.
+     *
+     * @see ForgeHooksClient#onGuiKeyPressedPost(Screen, int, int, int)
+     */
+
+/**
+ * @class net.minecraftforge.client.event.GuiScreenEvent.KeyboardKeyReleasedEvent
+ *
+ * Fired when a keyboard key is released.
+ * See the two subclasses for listening before and after the normal handling.
+ *
+ * @see KeyboardKeyReleasedEvent.Pre
+ * @see KeyboardKeyReleasedEvent.Post
+ */
+
+    /**
+     * @class net.minecraftforge.client.event.GuiScreenEvent.KeyboardKeyReleasedEvent.Pre
+     *
+     * Fired <b>before</b> the key release is handled by the screen.
+     *
+     * This event is \link Cancelable cancelable\endlink, and does not \link HasResult have a result\endlink.
+     * If the event is cancelled, the screen's key release handler will be bypassed
+     * and the corresponding \ref KeyboardKeyReleasedEvent.Post will not be fired.
+     *
+     * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+     * only on the \link LogicalSide#CLIENT logical client\endlink.
+     *
+     * @see ForgeHooksClient#onGuiKeyPressedPost(Screen, int, int, int)
+     */
+
+    /**
+     * @class net.minecraftforge.client.event.GuiScreenEvent.KeyboardKeyReleasedEvent.Post
+     *
+     * Fired <b>after</b> the key release is handled, if not handled by the screen
+     * and the corresponding \ref KeyboardKeyReleasedEvent.Pre is not cancelled.
+     *
+     * This event is \link Cancelable cancelable\endlink, and does not \link HasResult have a result\endlink.
+     * If the event is cancelled, the key release will be set as handled.
+     *
+     * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+     * only on the \link LogicalSide#CLIENT logical client\endlink.
+     *
+     * @see ForgeHooksClient#onGuiKeyReleasedPost(Screen, int, int, int)
+     */
+
+/**
+ * @class net.minecraftforge.client.event.GuiScreenEvent.KeyboardCharTypedEvent
+ *
+ * Fired when a keyboard key corresponding to a character is typed.
+ * See the two subclasses for listening before and after the normal handling.
+ *
+ * @see KeyboardCharTypedEvent.Pre
+ * @see KeyboardCharTypedEvent.Post
+ * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_char" target="_top">the online GLFW documentation</a>
+ */
+
+    /**
+     * @fn public char KeyboardCharTypedEvent::getCodePoint()
+     *
+     * Returns the code point of the typed character, stored as a \c char type.
+     *
+     * @return The character code point typed
+     */
+
+    /**
+     * @fn public int KeyboardCharTypedEvent::getModifiers()
+     *
+     * Returns a bit field number representing the currently active modifier keys.
+     *
+     * @return A bit field representing the active modifier keys
+     *
+     * @see GLFW#GLFW_MOD_SHIFT SHIFT modifier key bit
+     * @see GLFW#GLFW_MOD_CONTROL CTRL modifier key bit
+     * @see GLFW#GLFW_MOD_ALT ALT modifier key bit
+     * @see GLFW#GLFW_MOD_SUPER SUPER modifier key bit
+     * @see <a href="https://www.glfw.org/docs/latest/group__mods.html" target="_top">the online GLFW documentation</a>
+     */
+
+    /**
+     * @class net.minecraftforge.client.event.GuiScreenEvent.KeyboardCharTypedEvent.Pre
+     *
+     * Fired <b>before</b> the character input is handled by the screen.
+     *
+     * This event is \link Cancelable cancelable\endlink, and does not \link HasResult have a result\endlink.
+     * If the event is cancelled, the screen's character input handler will be bypassed
+     * and the corresponding \ref KeyboardCharTypedEvent.Post will not be fired.
+     *
+     * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+     * only on the \link LogicalSide#CLIENT logical client\endlink.
+     *
+     * @see ForgeHooksClient#onGuiCharTypedPre(Screen, char, int)
+     */
+
+    /**
+     * @class net.minecraftforge.client.event.GuiScreenEvent.KeyboardCharTypedEvent.Post
+     *
+     * Fired <b>after</b> the character input is handled, if not handled by the screen
+     * and the corresponding \ref KeyboardCharTypedEvent.Pre is not cancelled.
+     *
+     * This event is \link Cancelable cancelable\endlink, and does not \link HasResult have a result\endlink.
+     * If the event is cancelled, the character input will be set as handled.
+     *
+     * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+     * only on the \link LogicalSide#CLIENT logical client\endlink.
+     *
+     * @see ForgeHooksClient#onGuiCharTypedPost(Screen, char, int)
+     */

--- a/src/docs/net/minecraftforge/client/event/InputEvent.dox
+++ b/src/docs/net/minecraftforge/client/event/InputEvent.dox
@@ -1,0 +1,344 @@
+/**
+ * @class net.minecraftforge.client.event.InputEvent
+ *
+ * Fired when an input is detected from the user's input devices.
+ * See the various subclasses to listen for specific devices and inputs. 
+ *
+ * @see InputEvent.RawMouseEvent
+ * @see InputEvent.MouseInputEvent
+ * @see InputEvent.MouseScrollEvent
+ * @see InputEvent.KeyInputEvent
+ * @see InputEvent.ClickInputEvent
+ */
+
+/**
+ * @class net.minecraftforge.client.event.InputEvent.RawMouseEvent
+ *
+ * Fired when a mouse button is clicked, <b>before</b> being processed by vanilla code.
+ *
+ * This event is \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ * If the event is cancelled, then the mouse event will not be processed by vanilla code (e.g. keybinds and screens).
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink. 
+ *
+ * @see ForgeHooksClient#onRawMouseClicked(int, int, int)
+ * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_mouse_button" target="_top">the online GLFW documentation</a>
+ */
+
+    /**
+     * @fn public int RawMouseEvent::getButton()
+     *
+     * Returns the GLFW key code of the clicked mouse button.
+     *
+     * @return The key code of the clicked mouse button
+     *
+     * @see GLFW#GLFW_MOUSE_BUTTON_LEFT
+     * @see GLFW#GLFW_MOUSE_BUTTON_RIGHT
+     * @see GLFW#GLFW_MOUSE_BUTTON_MIDDLE
+     * @see GLFW key constants starting with 'GLFW_MOUSE_BUTTON_'
+     * @see <a href="http://www.glfw.org/docs/latest/input.html#input_mouse_button" target="_top">the online GLFW documentation</a>
+     */
+
+    /**
+     * @fn public int RawMouseEvent::getAction()
+     *
+     * Returns the action constant of the mouse button which triggered this event.
+     *
+     * @return The mouse button's action constant
+     *
+     * @see GLFW#GLFW_PRESS
+     * @see GLFW#GLFW_RELEASE
+     */
+
+    /**
+     * @fn public int RawMouseEvent::getMods()
+     *
+     * Returns a bit field number representing the currently active modifier keys.
+     *
+     * @return A bit field representing the active modifier keys
+     *
+     * @see GLFW#GLFW_MOD_SHIFT SHIFT modifier key bit
+     * @see GLFW#GLFW_MOD_CONTROL CTRL modifier key bit
+     * @see GLFW#GLFW_MOD_ALT ALT modifier key bit
+     * @see GLFW#GLFW_MOD_SUPER SUPER modifier key bit
+     * @see GLFW#GLFW_KEY_CAPS_LOCK CAPS LOCK modifier key bit
+     * @see GLFW#GLFW_KEY_NUM_LOCK NUM LOCK modifier key bit
+     * @see <a href="https://www.glfw.org/docs/latest/group__mods.html" target="_top">the online GLFW documentation</a>
+     */
+
+/**
+ * @class net.minecraftforge.client.event.InputEvent.MouseInputEvent
+ *
+ * Fired when a mouse button is clicked, <b>after</b> processing by vanilla code.
+ *
+ * This event is not \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink. 
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink. 
+ *
+ * @see ForgeHooksClient#fireMouseInput(int, int, int)
+ * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_mouse_button" target="_top">the online GLFW documentation</a>
+ */
+
+    /**
+     * @fn public int MouseInputEvent::getButton()
+     *
+     * Returns the GLFW key code of the mouse button which triggered this event.
+     *
+     * @return The key code of the mouse button
+     *
+     * @see GLFW#GLFW_MOUSE_BUTTON_LEFT
+     * @see GLFW#GLFW_MOUSE_BUTTON_RIGHT
+     * @see GLFW#GLFW_MOUSE_BUTTON_MIDDLE
+     * @see GLFW key constants starting with 'GLFW_MOUSE_BUTTON_'
+     * @see <a href="http://www.glfw.org/docs/latest/input.html#input_mouse_button" target="_top">the online GLFW documentation</a>
+     */
+
+    /**
+     * @fn public int MouseInputEvent::getAction()
+     *
+     * Returns the action constant of the mouse button action which triggered this event.
+     *
+     * @return The mouse button's action constant
+     *
+     * @see GLFW#GLFW_PRESS
+     * @see GLFW#GLFW_RELEASE
+     */
+
+    /**
+     * @fn public int MouseInputEvent::getMods()
+     *
+     * Returns a bit field number representing the currently active modifier keys.
+     *
+     * @return A bit field representing the active modifier keys
+     *
+     * @see GLFW#GLFW_MOD_SHIFT SHIFT modifier key bit
+     * @see GLFW#GLFW_MOD_CONTROL CTRL modifier key bit
+     * @see GLFW#GLFW_MOD_ALT ALT modifier key bit
+     * @see GLFW#GLFW_MOD_SUPER SUPER modifier key bit
+     * @see GLFW#GLFW_KEY_CAPS_LOCK CAPS LOCK modifier key bit
+     * @see GLFW#GLFW_KEY_NUM_LOCK NUM LOCK modifier key bit
+     * @see <a href="https://www.glfw.org/docs/latest/group__mods.html" target="_top">the online GLFW documentation</a>
+     */
+
+/**
+ * @class net.minecraftforge.client.event.InputEvent.MouseScrollEvent
+ *
+ * Fired when a mouse scroll wheel is used outside of a screen and a player is loaded,
+ * <b>before</b> being processed by vanilla code.
+ *
+ * This event is \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ * If the event is cancelled, then the mouse scroll event will not be processed further. 
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink. 
+ *
+ * @see ForgeHooksClient#onMouseScroll(MouseHelper, double)
+ * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_mouse_button" target="_top">the online GLFW documentation</a>
+ */
+
+    /**
+     * @fn public double MouseScrollEvent::getScrollDelta()
+     *
+     * Returns the amount of change or <em>delta</em> of the mouse scroll wheel.
+     *
+     * @return The delta of the mouse scroll
+     */
+
+    /**
+     * @fn public boolean MouseScrollEvent::isLeftDown()
+     *
+     * Returns if the left mouse button is currently pressed down.
+     *
+     * @return if the left mouse button is pressed
+     */
+
+    /**
+     * @fn public boolean MouseScrollEvent::isRightDown()
+     *
+     * Returns if the right mouse button is currently pressed down.
+     *
+     * @return if the right mouse button is pressed
+     */
+
+    /**
+     * @fn public boolean MouseScrollEvent::isMiddleDown()
+     *
+     * Returns if the middle mouse button is currently pressed down.
+     *
+     * @return if the middle mouse button is pressed
+     */
+
+    /**
+     * @fn public double MouseScrollEvent::getMouseX()
+     *
+     * Returns the X coordinate of the mouse pointer, relative to the \link MainWindow main window\endlink of the game.
+     *
+     * @return The X position of the mouse cursor
+     */
+
+    /**
+     * @fn public double MouseScrollEvent::getMouseY()
+     *
+     * Returns the X coordinate of the mouse pointer, relative to the \link MainWindow main window\endlink of the game.
+     *
+     * @return The Y position of the mouse cursor
+     */
+
+/**
+ * @class net.minecraftforge.client.event.InputEvent.KeyInputEvent
+ *
+ * Fired when a keyboard key input occurs, such as pressing, releasing, or repeating a key.
+ *
+ * This event is not \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink. 
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink. 
+ *
+ * @see ForgeHooksClient#fireKeyInput(int, int, int, int)
+ * @see InputMappings#getInputByCode(int, int)
+ */
+
+    /**
+     * @fn public int KeyInputEvent::getKey()
+     *
+     * Returns the GLFW (platform-agnostic) key code of the keyboard key.
+     *
+     * @return The GLFW (platform-agnostic) key code
+     *
+     * @see GLFW key constants starting with 'GLFW_KEY_'
+     * @see <a href="https://www.glfw.org/docs/latest/group__keys.html" target="_top">the online GLFW documentation</a>
+     */
+
+    /**
+     * @fn public int KeyInputEvent::getScanCode()
+     *
+     * Returns the platform-specific scan code of the keyboard key.
+     *
+     * The scan code is unique for every key, regardless of whether it has a key code.
+     * Scan codes are platform-specific but consistent over time, so keys will have different scan codes depending
+     * on the platform but they are safe to save to disk as custom key bindings.
+     *
+     * @return The platform-specific scan code
+     */
+
+    /**
+     * @fn public int KeyInputEvent::getAction()
+     *
+     * Returns the action constant of the keyboard key action which triggered this event.
+     *
+     * @return The keyboard key's action constant
+     *
+     * @see GLFW#GLFW_PRESS
+     * @see GLFW#GLFW_RELEASE
+     * @see GLFW#GLFW_REPEAT
+     */
+
+    /**
+     * @fn public int KeyInputEvent::getModifiers()
+     *
+     * Returns a bit field number representing the currently active modifier keys.
+     *
+     * @return A bit field representing the active modifier keys
+     *
+     * @see GLFW#GLFW_MOD_SHIFT SHIFT modifier key bit
+     * @see GLFW#GLFW_MOD_CONTROL CTRL modifier key bit
+     * @see GLFW#GLFW_MOD_ALT ALT modifier key bit
+     * @see GLFW#GLFW_MOD_SUPER SUPER modifier key bit
+     * @see GLFW#GLFW_KEY_CAPS_LOCK CAPS LOCK modifier key bit
+     * @see GLFW#GLFW_KEY_NUM_LOCK NUM LOCK modifier key bit
+     * @see <a href="https://www.glfw.org/docs/latest/group__mods.html" target="_top">the online GLFW documentation</a>
+     */
+
+/**
+ * @class net.minecraftforge.client.event.InputEvent.ClickInputEvent
+ *
+ * Fired when a keybinding that involves clicking the mouse buttons is triggered.
+ *
+ * The key bindings that trigger this event are:
+ * <ul>
+ *     <li>\link GameSettings#keyBindAttack <b>Attack</b>\endlink - defaults to <em>left mouse click</em></li>
+ *     <li>\link GameSettings#keyBindUseItem <b>Use Item</b>\endlink - defaults to <em>right mouse click</em></li>
+ *     <li>\link GameSettings#keyBindPickBlock <b>Pick Block</b>\endlink - defaults to <em>middle mouse click</em></li>
+ * </ul>
+ *
+ * This event is \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ * If this event is cancelled, then the keybind's action is not processed further, and the hand will be swung
+ * according to \ref #shouldSwingHand().
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink. 
+ *
+ * @see ForgeHooksClient#onClickInput(int, KeyBinding, Hand)
+ */
+
+    /**
+     * @fn public void ClickInputEvent::setSwingHand(boolean value)
+     *
+     * Sets whether to swing the player entity's hand.
+     * This takes effect even if the event is cancelled.
+     * The default value is \c true.
+     *
+     * @param value whether to swing the hand
+     */
+
+    /**
+     * @fn public boolean ClickInputEvent::shouldSwingHand()
+     *
+     * Returns whether to swing the player entity's hand.
+     * This takes effect even if the event is cancelled.
+     *
+     * @return Whether to swing the hand
+     * @see #setSwingHand(boolean)
+     */
+
+    /**
+     * @fn public Hand ClickInputEvent::getHand()
+     *
+     * The hand which triggered this event.
+     *
+     * The event will be called for both hands if this is a <em>use item</em> action,
+     * regardless of both event's cancellation.
+     * This will always be \ref Hand#MAIN_HAND if this is an attack or pick block input.
+     *
+     * @return The hand causing the input
+     */
+
+    /**
+     * @fn public boolean ClickInputEvent::isAttack()
+     *
+     * Returns if the clicked mouse button is the left mouse button.
+     *
+     * This is named due to the left mouse button being the default \link GameSettings#keyBindAttack <b>Attack</b> keybind\endlink.
+     *
+     * @return if the mouse button is the left mouse button
+     */
+
+    /**
+     * @fn public boolean ClickInputEvent::isUseItem()
+     *
+     * Returns if the clicked mouse button is the right mouse button.
+
+     * This is named due to the right mouse button being the default \link GameSettings#keyBindUseItem <b>Use Item</b> keybind\endlink.
+     *
+     * @return if the mouse button is the right mouse button
+     */
+
+    /**
+     * @fn public boolean ClickInputEvent::isPickBlock()
+     *
+     * Returns if the clicked mouse button is the middle mouse button.
+
+     * This is named due to the middle mouse button being the default \link GameSettings#keyBindPickBlock <b>Pick Block</b> keybind\endlink.
+     *
+     * @return if the mouse button is the middle mouse button
+     */
+
+    /**
+     * @fn public KeyBinding ClickInputEvent::getKeyBinding()
+     *
+     * Returns the \ref KeyBinding that triggered this event.
+     *
+     * @return The keybinding that triggered this event
+     */

--- a/src/docs/net/minecraftforge/client/event/InputUpdateEvent.dox
+++ b/src/docs/net/minecraftforge/client/event/InputUpdateEvent.dox
@@ -1,0 +1,20 @@
+/**
+ * @class net.minecraftforge.client.event.InputUpdateEvent
+ *
+ * Fired after player movement inputs are updated.
+ *
+ * This event is not \link Cancelable cancelable\endlink, and does not \link HasResult have a result\endlink.
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ *
+ * @see ForgeHooksClient#onInputUpdate(PlayerEntity, MovementInput)
+ */
+
+/**
+ * @fn public MovementInput InputUpdateEvent::getMovementInput()
+ *
+ * Returns the player's current movement inputs.
+ *
+ * @return The player's movement inputs
+ */

--- a/src/docs/net/minecraftforge/client/event/ModelBakeEvent.dox
+++ b/src/docs/net/minecraftforge/client/event/ModelBakeEvent.dox
@@ -1,0 +1,41 @@
+/**
+ * @class net.minecraftforge.client.event.ModelBakeEvent
+ *
+ * Fired when the ModelManager is notified of the resource manager reloading.
+ * Called after model registry is setup, but before it's passed to \ref BlockModelShapes for block model baking.
+ * This can be used to modify and wrap models before they are sent for model baking.
+ *
+ * This event is not \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ *
+ * These events are fired on the \link FMLJavaModLoadingContext#getModEventBus() mod-specific event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ *
+ * @see ForgeHooksClient#onModelBake(ModelManager, Map, ModelLoader)
+ */
+
+/**
+ * @fn public ModelManager ModelBakeEvent::getModelManager()
+ *
+ * Returns the \ref ModelManager.
+ *
+ * @return The model manager
+ */
+
+/**
+ * @fn public Map<ResourceLocation, IBakedModel> ModelBakeEvent::getModelRegistry()
+ *
+ * Returns a modifiable map of \link ResourceLocation ResourceLocations\endlink and their corresponding models.
+ *
+ * The \c ResourceLocations in the map can also be instances of \ref ModelResourceLocation,
+ * for e.g. models for block states and their variants.
+ *
+ * @return The modifiable registry map of models and their model names
+ */
+
+/**
+ * @fn public ModelLoader ModelBakeEvent::getModelLoader()
+ *
+ * Returns the currently active \ref ModelLoader.
+ *
+ * @return The model loader
+ */

--- a/src/docs/net/minecraftforge/client/event/ModelRegistryEvent.dox
+++ b/src/docs/net/minecraftforge/client/event/ModelRegistryEvent.dox
@@ -1,0 +1,13 @@
+/**
+ * @class net.minecraftforge.client.event.ModelRegistryEvent
+ *
+ * Fired when the \ref ModelLoader is ready for model loader registrations.
+ *
+ * This event is not \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ *
+ * This event is fired on the \link FMLJavaModLoadingContext#getModEventBus() mod-specific event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ *
+ * @see ModelLoaderRegistry#onModelLoadingStart()
+ * @see ModelLoaderRegistry#registerLoader(ResourceLocation, IModelLoader)
+ */

--- a/src/docs/net/minecraftforge/client/event/ParticleFactoryRegisterEvent.dox
+++ b/src/docs/net/minecraftforge/client/event/ParticleFactoryRegisterEvent.dox
@@ -1,0 +1,16 @@
+/**
+ * @class net.minecraftforge.client.event.ParticleFactoryRegisterEvent
+ *
+ * Fired for registering particle factories at the appropriate time.
+ *
+ * \link ParticleType ParticleTypes\endlink must be registered during the
+ * \link RegistryEvent.Register appropriate registry events\endlink; this event is only
+ * for the \link IParticleFactory IParticleFactories\endlink. </p>
+ *
+ * This event is not \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ *
+ * This event is fired on the \link FMLJavaModLoadingContext#getModEventBus() mod-specific event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ *
+ * @see ParticleManager#registerFactory(ParticleType, IParticleFactory)
+ */

--- a/src/docs/net/minecraftforge/client/event/RecipesUpdatedEvent.dox
+++ b/src/docs/net/minecraftforge/client/event/RecipesUpdatedEvent.dox
@@ -1,0 +1,20 @@
+/**
+ * @class net.minecraftforge.client.event.RecipesUpdatedEvent
+ *
+ * Fired when the {@link RecipeManager} has synced the recipes from the server to the client.
+ *
+ * This event is not \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ *
+ * @see ForgeHooksClient#onRecipesUpdated(RecipeManager)
+ */
+
+/**
+ * @fn public RecipeManager RecipesUpdatedEvent::getRecipeManager()
+ *
+ * Returns the currently active \ref RecipeManager.
+ *
+ * @return The recipe manager
+ */

--- a/src/docs/net/minecraftforge/client/event/RenderBlockOverlayEvent.dox
+++ b/src/docs/net/minecraftforge/client/event/RenderBlockOverlayEvent.dox
@@ -1,0 +1,71 @@
+/**
+ * @class net.minecraftforge.client.event.RenderBlockOverlayEvent
+ *
+ * Fired before a block texture will be overlaid on the player's view.
+ *
+ * This event is \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ * If this event is cancelled, then the overlay will not be rendered.
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ *
+ * @see ForgeEventFactory#renderBlockOverlay(PlayerEntity, MatrixStack, OverlayType, BlockState, BlockPos)
+ */
+
+/**
+ * @class net.minecraftforge.client.event.RenderBlockOverlayEvent.OverlayType
+ *
+ * Defines the different overlays that may be rendered.
+ *
+ * @see RenderBlockOverlayEvent
+ */
+
+    /**
+     * @var OverlayType::FIRE
+     *
+     * The type of the overlay when the player is burning / on fire.
+     */
+
+    /**
+     * @var OverlayType::BLOCK
+     *
+     * The type of overlay when the player is suffocating inside a solid block.
+     */
+
+    /**
+     * @var OverlayType::WATER
+     *
+     * The type of overlay when the player is underwater.
+     */
+
+/**
+ * @fn public PlayerEntity RenderBlockOverlayEvent::getPlayer()
+ *
+ * @return The player which the overlay will apply to
+ */
+
+/**
+ * @fn public MatrixStack RenderBlockOverlayEvent::getMatrixStack()
+ *
+ * Returns the \ref MatrixStack used for transformations, rotations, and scaling in rendering.
+ *
+ * @return The matrix stack used for rendering
+ */
+
+/**
+ * @fn public OverlayType RenderBlockOverlayEvent::getOverlayType()
+ *
+ * @return The type of the overlay
+ */
+
+/**
+ * @fn public BlockState RenderBlockOverlayEvent::getBlockForOverlay()
+ *
+ * @return The block from which the overlay is gotten from
+ */
+
+/**
+ * @fn public BlockPos RenderBlockOverlayEvent::getBlockPos()
+ *
+ * @return The position of the block from which the overlay is gotten from
+ */

--- a/src/docs/net/minecraftforge/client/event/RenderHandEvent.dox
+++ b/src/docs/net/minecraftforge/client/event/RenderHandEvent.dox
@@ -1,0 +1,100 @@
+/**
+ * @class net.minecraftforge.client.event.RenderHandEvent
+ *
+ * Fired before a hand is rendered in the first person view.
+ *
+ * This event is \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ * If this event is cancelled, then the hand will not be rendered.
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ *
+ * @see ForgeHooksClient#renderSpecificFirstPersonHand(Hand, MatrixStack, IRenderTypeBuffer, int, float, float, float, float, ItemStack)
+ */
+
+/**
+ * @fn public Hand RenderHandEvent::getHand()
+ *
+ * Returns the hand being rendered during this event.
+ *
+ * @return the hand being rendered
+ */
+
+/**
+ * @fn public MatrixStack RenderHandEvent::getMatrixStack()
+ *
+ * Returns the \ref MatrixStack used for transformations, rotations, and scaling in rendering.
+ *
+ * @return the matrix stack used for rendering
+ */
+
+/**
+ * @fn public IRenderTypeBuffer RenderHandEvent::getBuffers()
+ *
+ * Returns the \ref IRenderTypeBuffer currently being used for rendering.
+ *
+ * @return the rendering buffers
+ */
+
+/**
+ * @fn public int RenderHandEvent::getLight()
+ *
+ * Returns an integer packed with the sky and block light.
+ * This is used in rendering to determine the color of the light level of the block, according to the light texture.
+ *
+ * @return The amount of packed light for rendering
+ * @see LightTexture
+ * @see LightTexture#packLight(int, int)
+ * @see LightTexture#getLightBlock(int)
+ * @see LightTexture#getLightSky(int)
+ */
+
+/**
+ * @fn public float RenderHandEvent::getPartialTicks()
+ *
+ * Returns the partial amount of ticks between the last and next render tick.
+ * This will be in the range of <tt>0.0-1.0</tt>.
+ *
+ * @return The amount of partial ticks
+ */
+
+/**
+ * @fn public float RenderHandEvent::getInterpolatedPitch()
+ *
+ * Returns the interpolated rotation pitch of the player entity.
+ * It is the linear interpolation between the previous and current rotation pitch of the player, based on the
+ * \link #getPartialTicks() partial ticks\endlink.
+ *
+ * @return The interpolated pitch of the player entity
+ */
+
+/**
+ * @fn public float RenderHandEvent::getSwingProgress()
+ *
+ * Returns the progress of the swing animation of the hand.
+ * This is affected by certain effects, such as the Mining Fatigue or Haste effects.
+ *
+ * This \c float value is in the range of <tt>0.0-1.0</tt>
+ *
+ * @return The swing progress of the hand being rendered
+ * @see LivingEntity#getSwingProgress(float)
+ */
+
+/**
+ * @fn public float RenderHandEvent::getEquipProgress()
+ *
+ * Returns the interpolated progress of the equip animation of the hand.
+ * It is the linear interpolation between the previous and current equip animation of the hand, based on the
+ * \link #getPartialTicks() partial ticks\endlink.
+ * This \c float value is in the range of <tt>0.0-1.0</tt>
+ *
+ * @return The progress of the equip animation
+ */
+
+/**
+ * @fn public ItemStack RenderHandEvent::getItemStack()
+ *
+ * Returns the \ref ItemStack currently held in this \link #getHand() hand\endlink.
+ *
+ * @return The item stack held in the hand
+ */

--- a/src/docs/net/minecraftforge/client/event/RenderItemInFrameEvent.dox
+++ b/src/docs/net/minecraftforge/client/event/RenderItemInFrameEvent.dox
@@ -1,0 +1,67 @@
+/**
+ * @class net.minecraftforge.client.event.RenderItemInFrameEvent
+ *
+ * Fired before an item stack is rendered in an item frame.
+ * This can be used to prevent normal rendering and add custom rendering.
+ *
+ * This event is \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ * If the event is cancelled, then the item frame's item stack will not be rendered.
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ *
+ * @see ItemFrameRenderer
+ */
+
+/**
+ * @fn public ItemStack RenderItemInFrameEvent::getItem()
+ *
+ * Returns the \ref ItemStack stored in the \link #getEntityItemFrame() item frame entity\endlink that will be rendered.
+ *
+ * @return The item stack being rendered
+ */
+
+/**
+ * @fn public ItemFrameEntity RenderItemInFrameEvent::getEntityItemFrame()
+ *
+ * Returns the \ref ItemFrameEntity for this event.
+ *
+ * @return The item frame entity
+ */
+
+/**
+ * @fn public ItemFrameRenderer RenderItemInFrameEvent::getRenderer()
+ *
+ * Returns the \link ItemFrameRenderer renderer\endlink for the \ref ItemFrameEntity.
+ *
+ * @return The renderer for the item frame entity
+ */
+
+/**
+ * @fn public MatrixStack RenderItemInFrameEvent::getMatrix()
+ *
+ * Returns the \ref MatrixStack used for transformations, rotations, and scaling in rendering.
+ *
+ * @return The matrix stack used for rendering
+ */
+
+/**
+ * @fn public IRenderTypeBuffer RenderItemInFrameEvent::getBuffers()
+ *
+ * Returns the \ref IRenderTypeBuffer currently being used for rendering.
+ *
+ * @return The rendering buffers
+ */
+
+/**
+ * @fn public int RenderItemInFrameEvent::getLight()
+ *
+ * Returns an integer packed with the sky and block light.
+ * This is used in rendering to determine the color of the light level of the block, according to the light texture.
+ *
+ * @return The amount of packed light for rendering
+ * @see LightTexture
+ * @see LightTexture#packLight(int, int)
+ * @see LightTexture#getLightBlock(int)
+ * @see LightTexture#getLightSky(int)
+ */

--- a/src/docs/net/minecraftforge/client/event/RenderLivingEvent.dox
+++ b/src/docs/net/minecraftforge/client/event/RenderLivingEvent.dox
@@ -1,0 +1,95 @@
+/**
+ * @class net.minecraftforge.client.event.RenderLivingEvent
+ *
+ * Fired when a {@link LivingEntity} is rendered.
+ * See the two subclasses to listen for before and after rendering.
+ *
+ * @param <T> the living entity that is being rendered
+ * @param <M> the model for the living entity
+ *
+ * @see RenderLivingEvent.Pre
+ * @see RenderLivingEvent.Post
+ * @see RenderPlayerEvent
+ * @see LivingRenderer
+ */
+
+/**
+ * @fn public LivingEntity RenderLivingEvent::getEntity()
+ *
+ * Returns the \ref LivingEntity instance that is being rendered.
+ *
+ * @return the living entity being rendered
+ */
+
+/**
+ * @fn public LivingRenderer<T, M> RenderLivingEvent::getRenderer()
+ *
+ * Returns the \ref LivingRenderer for the living entity.
+ *
+ * @return The renderer for the living entity
+ */
+
+/**
+ * @fn public float RenderLivingEvent::getPartialRenderTick()
+ *
+ * Returns the partial amount of ticks between the last and next render tick.
+ * This will be in the range of <tt>0.0-1.0</tt>.
+ *
+ * @return The amount of partial ticks
+ */
+
+/**
+ * @fn public MatrixStack RenderLivingEvent::getMatrixStack()
+ *
+ * Returns the \ref MatrixStack used for transformations, rotations, and scaling in rendering.
+ *
+ * @return The matrix stack used for rendering
+ */
+
+/**
+ * @fn public IRenderTypeBuffer RenderLivingEvent::getBuffers()
+ *
+ * Returns the \ref IRenderTypeBuffer currently being used for rendering.
+ *
+ * @return The rendering buffers
+ */
+
+/**
+ * @fn public int RenderLivingEvent::getLight()
+ *
+ * Returns an integer packed with the sky and block light.
+ * This is used in rendering to determine the color of the light level of the block, according to the light texture.
+ *
+ * @return The amount of packed light for rendering
+ * @see LightTexture
+ * @see LightTexture#packLight(int, int)
+ * @see LightTexture#getLightBlock(int)
+ * @see LightTexture#getLightSky(int)
+ */
+
+/**
+ * Fired <b>before</b> an entity is rendered.
+ * This can be used to render additional effects or suppress rendering.
+ *
+ * This event is \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ * If this event is cancelled, then the entity will not be rendered and the corresponding
+ * \ref RenderLivingEvent.Post will not be fired.
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ *
+ * @param <T> The living entity that is being rendered
+ * @param <M> The model for the living entity
+ */
+
+/**
+ * Fired <b>after</b> an entity is rendered, if the corresponding {@link RenderLivingEvent.Post} is not cancelled.
+ *
+ * This event is not \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ *
+ * @param <T> The living entity that was rendered
+ * @param <M> The model for the living entity
+ */

--- a/src/docs/net/minecraftforge/client/event/RenderNameplateEvent.dox
+++ b/src/docs/net/minecraftforge/client/event/RenderNameplateEvent.dox
@@ -1,0 +1,87 @@
+/**
+ * @class net.minecraftforge.client.event.RenderNameplateEvent
+ *
+ * Fired before an entity renderer renders the nameplate of an entity.
+ *
+ * This event is not \link Cancelable cancellable\endlink, and  \link HasResult has a result\endlink.
+ * <ul>
+ *     <li><tt>ALLOW</tt> - The nameplate will be forcibly rendered.</li>
+ *     <li><tt>DEFAULT</tt> - The vanilla logic will be used.</li>
+ *     <li><tt>DENY</tt> - The nameplate will not be rendered.</li>
+ * </ul>
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ *
+ * @see EntityRenderer#render(T, float, float, MatrixStack, IRenderTypeBuffer, int)
+ */
+
+/**
+ * @fn public void RenderNameplateEvent::setContent(ITextComponent contents)
+ *
+ * Sets the new text to be rendered on the nameplate.
+ *
+ * @param contents The new nameplate text
+ */
+
+/**
+ * @fn public ITextComponent RenderNameplateEvent::getContent()
+ *
+ * Returns the text to be rendered on the nameplate, if the event is not \link Result#DENY DENIED\endlink.
+ *
+ * @return The text of the nameplate
+ */
+
+/**
+ * @fn public ITextComponent RenderNameplateEvent::getOriginalContent()
+ *
+ * Returns the original text of the nameplate, before any modifications by this event.
+ *
+ * @return The original text of the nameplate
+ */
+
+/**
+ * @fn public EntityRenderer<?> RenderNameplateEvent::getEntityRenderer()
+ *
+ * Returns the \ref EntityRenderer for the entity that this nameplate is being rendered for.
+ *
+ * @return The entity renderer rendering the nameplate
+ */
+
+/**
+ * @fn public MatrixStack RenderNameplateEvent::getMatrixStack()
+ *
+ * Returns the \ref MatrixStack used for transformations, rotations, and scaling in rendering.
+ *
+ * @return The matrix stack used for rendering
+ */
+
+/**
+ * @fn public IRenderTypeBuffer RenderNameplateEvent::getRenderTypeBuffer()
+ *
+ * Returns the \ref IRenderTypeBuffer currently being used for rendering.
+ *
+ * @return The rendering buffers
+ */
+
+/**
+ * @fn public int RenderNameplateEvent::getPackedLight()
+ *
+ * Returns an integer packed with the sky and block light.
+ * This is used in rendering to determine the color of the light level of the block, according to the light texture.
+ *
+ * @return The amount of packed light for rendering
+ * @see LightTexture
+ * @see LightTexture#packLight(int, int)
+ * @see LightTexture#getLightBlock(int)
+ * @see LightTexture#getLightSky(int)
+ */
+
+/**
+ * @fn public float RenderNameplateEvent::getPartialTicks()
+ *
+ * Returns the partial amount of ticks between the last and next render tick.
+ * This will be in the range of <tt>0.0-1.0</tt>.
+ *
+ * @return The amount of partial ticks
+ */

--- a/src/docs/net/minecraftforge/client/event/RenderPlayerEvent.dox
+++ b/src/docs/net/minecraftforge/client/event/RenderPlayerEvent.dox
@@ -1,0 +1,81 @@
+/**
+ * @class net.minecraftforge.client.event.RenderPlayerEvent
+ *
+ * Fired when a player is being rendered.
+ * See the two subclasses for listening for before and after rendering.
+ *
+ * @see RenderPlayerEvent.Pre
+ * @see RenderPlayerEvent.Post
+ * @see PlayerRenderer
+ */
+
+/**
+ * @fn public PlayerRenderer RenderPlayerEvent::getRenderer()
+ *
+ * Returns the \ref PlayerRenderer for the player entity.
+ *
+ * @return The renderer for the player entity
+ */
+
+/**
+ * @fn public float RenderPlayerEvent::getPartialRenderTick()
+ *
+ * Returns the partial amount of ticks between the last and next render tick.
+ * This will be in the range of <tt>0.0-1.0</tt>.
+ *
+ * @return The amount of partial ticks
+ */
+
+/**
+ * @fn public MatrixStack RenderPlayerEvent::getMatrixStack()
+ *
+ * Returns the \ref MatrixStack used for transformations, rotations, and scaling in rendering.
+ *
+ * @return The matrix stack used for rendering
+ */
+
+/**
+ * @fn public IRenderTypeBuffer RenderPlayerEvent::getBuffers()
+ *
+ * Returns the \ref IRenderTypeBuffer currently being used for rendering.
+ *
+ * @return The rendering buffers
+ */
+
+/**
+ * @fn public int RenderPlayerEvent::getLight()
+ *
+ * Returns an integer packed with the sky and block light.
+ * This is used in rendering to determine the color of the light level of the block, according to the light texture.
+ *
+ * @return The amount of packed light for rendering
+ * @see LightTexture
+ * @see LightTexture#packLight(int, int)
+ * @see LightTexture#getLightBlock(int)
+ * @see LightTexture#getLightSky(int)
+ */
+
+/**
+ * @class net.minecraftforge.client.event.RenderPlayerEvent.Pre
+ *
+ * Fired <b>before</b> the player is rendered.
+ * This can be used for rendering additional effects or suppressing rendering.
+ *
+ * This event is \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ * If this event is cancelled, then the player will not be rendered and the corresponding
+ * \ref RenderPlayerEvent.Post will not be fired.
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ */
+
+/**
+ * @class net.minecraftforge.client.event.RenderPlayerEvent.Post
+ *
+ * Fired <b>after</b> the player is rendered, if the corresponding \ref RenderPlayerEvent.Pre is not cancelled.
+ *
+ * This event is not \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ */

--- a/src/docs/net/minecraftforge/client/event/RenderTooltipEvent.dox
+++ b/src/docs/net/minecraftforge/client/event/RenderTooltipEvent.dox
@@ -1,0 +1,302 @@
+/**
+ * @class net.minecraftforge.client.event.RenderTooltipEvent
+ *
+ * Fired when a tooltip is rendering.
+ * See the various subclasses for listening to specific events.
+ *
+ * @see RenderTooltipEvent.Pre
+ * @see RenderTooltipEvent.Post
+ * @see RenderTooltipEvent.Color
+ * @see GuiUtils#drawHoveringText(ItemStack, MatrixStack, List, int, int, int, int, int, int, int, int, FontRenderer)
+ */
+
+/**
+ * @fn public ItemStack RenderTooltipEvent::getStack()
+ *
+ * Returns the \ref ItemStack for which the tooltip is being rendered.
+ *
+ * In certain situations where a tooltip is rendered without an \ref ItemStack, this will be the value of
+ * \ref GuiUtils#cachedTooltipStack, which has the value of \ref ItemStack#EMPTY.
+ *
+ * @return The stack which the tooltip is being rendered for, may be \ref ItemStack#EMPTY
+ */
+
+/**
+ * @fn public List<? extends ITextProperties> RenderTooltipEvent::getLines()
+ *
+ * Returns an unmodifiable view of the lines of text on the tooltip, as represented by \ref ITextProperties.
+ * This may change between \ref RenderTooltipEvent.Pre and \ref RenderTooltipEvent.Post.
+ *
+ * <em>Use \ref ItemTooltipEvent to modify the text of the tooltip.</em>
+ *
+ * @return An unmodifiable view of list of text on the tooltip
+ * @see ItemTooltipEvent
+ */
+
+/**
+ * @fn public MatrixStack RenderTooltipEvent::getMatrixStack()
+ *
+ * Returns the \ref MatrixStack used for transformations, rotations, and scaling in rendering the tooltip.
+ *
+ * @return The matrix stack used for rendering
+ */
+
+/**
+ * @fn public int RenderTooltipEvent::getX()
+ *
+ * Returns the X position of where the tooltip box will be rendered.
+ * When rendering a tooltip for an itemstack, this will by default the X position of the mouse cursor.
+ *
+ * @return The X position of the tooltip box
+ * @see RenderTooltipEvent.Pre::setX(int)
+ */
+
+/**
+ * @fn public int RenderTooltipEvent::getY()
+ *
+ * Returns the Y position of where the tooltip box will be rendered.
+ * When rendering a tooltip for an itemstack, this will by default be the Y position of the mouse cursor.
+ *
+ * @return The Y position of the tooltip box
+ * @see RenderTooltipEvent.Pre::setY(int)
+ */
+
+/**
+ * @fn public FontRenderer RenderTooltipEvent::getFontRenderer()
+ *
+ * Returns the \ref FontRenderer used for rendering the text.
+ *
+ * @return The font renderer
+ * @see RenderTooltipEvent.Pre::setFontRenderer(int)
+ */
+
+/**
+ * @class net.minecraftforge.client.event.RenderTooltipEvent.Pre
+ *
+ * Fired <b>before</b> the tooltip is rendered.
+ * This can be used to modify the positioning of the tooltip.
+ *
+ * This event is \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ * If this event is cancelled, then the tooltip will not be rendered and the corresponding
+ * \ref RenderTooltipEvent.Color, \ref RenderTooltipEvent.PostBackground, and
+ * \ref RenderTooltipEvent.PostText will not be fired.
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ */
+
+    /**
+     * @fn public int Pre::getScreenWidth()
+     *
+     * Returns the perceived width of the screen.
+     * This is used in wrapping the tooltip text within the bounds of the screen.
+     *
+     * This may not reflect the actual dimensions of the game window/screen,
+     * as it can be adjusted using \ref Pre#setScreenWeight(int).
+     *
+     * @return The width of the screen
+     */
+
+    /**
+     * @fn public void Pre::setScreenWidth(int screenWidth)
+     *
+     * Sets the new perceived width of the screen.
+     * This is used in wrapping the tooltip text within the bounds of the screen.
+     *
+     * @param screenWidth The new width of the screen.
+     */
+
+    /**
+     * @fn public int Pre::getScreenHeight()
+     *
+     * Returns the perceived height of the screen.
+     * This is used in wrapping the tooltip text within the bounds of the screen.
+     *
+     * This may not reflect the actual dimensions of the game window/screen,
+     * as it can be adjusted using \ref Pre#setScreenHeight(int).
+     *
+     * @return The height of the screen
+     */
+
+    /**
+     * @fn public void Pre::setScreenHeight(int screenHeight)
+     *
+     * Sets the new perceived height of the screen.
+     * This is used in wrapping the tooltip text within the bounds of the screen.
+     *
+     * @param screenWidth The new height of the screen.
+     */
+
+    /**
+     * @fn public int Pre::getMaxWidth()
+     *
+     * Returns the maximum width of the tooltip when being rendered.
+     * A value of \c -1 means an unlimited maximum width.
+     *
+     * @return The maximum width
+     */
+
+    /**
+     * @fn public void Pre::setMaxWidth(int maxWidth)
+     *
+     * Sets the maximum width of the tooltip.
+     * Use \c -1 for unlimited maximum width.
+     *
+     * @param maxWidth The new maximum width
+     */
+
+    /**
+     * @fn public void Pre::setFontRenderer(FontRenderer fr)
+     *
+     * Sets the \ref FontRenderer to be used to render text.
+     *
+     * @param fr The new font renderer
+     */
+
+    /**
+     * @fn public void Pre::setX(int x)
+     *
+     * Sets the new X position of where the tooltip box will be rendered.
+     *
+     * @param x The new X position of the tooltip
+     */
+
+    /**
+     * @fn public void Pre::setY(int y)
+     *
+     * Sets the new Y position of where the tooltip box will be rendered.
+     *
+     * @param y The new Y position of the tooltip
+     */
+
+/**
+ * @class net.minecraftforge.client.event.RenderTooltipEvent.Post
+ *
+ * Fired <b>after</b> the tooltip is rendered, at different points.
+ * See the two subclasses for listening to after background or after text rendering.
+ *
+ * @see RenderTooltipEvent.PostBackground
+ * @see RenderTooltipEvent.PostText
+ */
+
+    /**
+     * @fn public int Post::getWidth()
+     *
+     * Returns the width of the inner tooltip box, which does not include the border's width.
+     *
+     * @return The width of the inner tooltip box (not including border)
+     */
+
+    /**
+     * @fn public int Post::getHeight()
+     *
+     * Returns the height of the inner tooltip box, which does not include the border's height.
+     *
+     * @return The height of the inner tooltip box (not including border)
+     */
+
+/**
+ * @class net.minecraftforge.client.event.RenderTooltipEvent.PostBackground
+ *
+ * Fired <b>after</b> the tooltip background is rendered, and <em>before</em> the tooltip text is rendered.
+ *
+ * This event is not \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ */
+
+/**
+ * @class net.minecraftforge.client.event.RenderTooltipEvent.PostText
+ *
+ * Fired <b>after</b> the tooltip text is rendered.
+ *
+ * This event is not \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ */
+
+/**
+ * @class net.minecraftforge.client.event.RenderTooltipEvent.Color
+ *
+ * Fired <em>directly <b>before</b> the tooltip background</em> is rendered. <br/>
+ * This can be used to modify the background color and the border's gradient colors.
+ *
+ * This event is not \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ */
+
+    /**
+     * @fn public int Color::getBackground()
+     *
+     * Returns the background color of the tooltip.
+     *
+     * @return The background color of the tooltip
+     */
+
+    /**
+     * @fn public void Color::setBackground(int background)
+     *
+     * Sets the new color for the background of the tooltip.
+     *
+     * @param background the new tooltip background color
+     */
+
+    /**
+     * @fn public int Color::getBorderStart()
+     *
+     * Returns the start color of the tooltip's border.
+     *
+     * @return The start color for the tooltip border
+     */
+
+    /**
+     * @fn public void Color::setBorderStart(int borderStart)
+     *
+     * Sets the new start color for the gradient of the tooltip border.
+     *
+     * @param borderStart the new start color for the tooltip border
+     */
+
+    /**
+     * @fn public int Color::getBorderEnd()
+     *
+     * Returns the end color of the tooltip's border.
+     *
+     * @return the end color for the tooltip border
+     */
+
+    /**
+     * @fn public void Color::setBorderEnd(int borderEnd)
+     *
+     * Sets the new end color for the gradient of the tooltip border.
+     *
+     * @param borderEnd the new end color for the tooltip border
+     */
+
+    /**
+     * @fn public int Color::getOriginalBackground()
+     *
+     * Returns the original color of the tooltip's background, before any modifications by this event.
+     *
+     * @return the original tooltip background color
+     */
+
+    /**
+     * @fn public int Color::getOriginalBorderStart()
+     *
+     * Returns the original start color of the tooltip's border, before any modifications by this event.
+     *
+     * @return the original tooltip border's start color
+     */
+
+    /**
+     * @fn public int Color::getOriginalBorderEnd()
+     *
+     * Returns the original end color of the tooltip's border, before any modifications by this event.
+     *
+     * @return the original tooltip border's end color
+     */

--- a/src/docs/net/minecraftforge/client/event/RenderWorldLastEvent.dox
+++ b/src/docs/net/minecraftforge/client/event/RenderWorldLastEvent.dox
@@ -1,0 +1,64 @@
+/**
+ * @class net.minecraftforge.client.event.RenderWorldLastEvent
+ *
+ * Fired after world rendering is finished.
+ * This can be used for custom rendering outside of e.g. a tile entity or entity renderer.
+ *
+ * Rendering in this event occurs after all world rendering (after the render buffers are flushed);
+ * interactions with translucent rendering and other special effects may have unavoidable side-effects.
+ *
+ * An instance of \ref IRenderTypeBuffer can be retrieved from \ref RenderTypeBuffers#getBufferSource().
+ * The caller is responsible for flushing the buffers after use, through \ref RenderTypeBuffers.Impl#finish().
+ * <em>Not flushing the buffers will cause rendering issues.</em>
+ *
+ * This event is not \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ *
+ * This event is fired on the \link MinecraftForge#EVENT_BUS main Forge event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ *
+ * @see ForgeHooksClient#dispatchRenderLast(WorldRenderer, MatrixStack, float, Matrix4f, long)
+ * @see GameRenderer
+ * @see WorldRenderer
+ */
+
+/**
+ * @fn public WorldRenderer RenderWorldLastEvent::getContext()
+ *
+ * Returns the \ref WorldRenderer.
+ *
+ * @return The world renderer
+ */
+
+/**
+ * @fn public MatrixStack RenderWorldLastEvent::getMatrixStack()
+ *
+ * Returns the \ref MatrixStack used for transformations, rotations, and scaling in rendering.
+ *
+ * @return The matrix stack used for rendering
+ */
+
+/**
+ * @fn public float RenderWorldLastEvent::getPartialTicks()
+ *
+ * Returns the partial amount of ticks between the last and next render tick.
+ * This will be in the range of <tt>0.0-1.0</tt>.
+ *
+ * @return The amount of partial ticks
+ */
+
+/**
+ * @fn public Matrix4f RenderWorldLastEvent::getProjectionMatrix()
+ *
+ * Returns the projection matrix.
+ *
+ * @return The projection matrix
+ */
+
+/**
+ * @fn public long RenderWorldLastEvent::getFinishTimeNano()
+ *
+ * Returns the time when rendering started, expressed in nanoseconds.
+ *
+ * @return The time when rendering started, in nanoseconds
+ * @see Util#nanoTime()
+ */

--- a/src/docs/net/minecraftforge/client/event/TextureStitchEvent.dox
+++ b/src/docs/net/minecraftforge/client/event/TextureStitchEvent.dox
@@ -1,0 +1,53 @@
+/**
+ * @class net.minecraftforge.client.event.TextureStitchEvent
+ *
+ * Fired when the texture map is stitched together.
+ * See the two subclasses to listen for before and after stitching.
+ *
+ * @see TextureStitchEvent.Pre
+ * @see TextureStitchEvent.Post
+ * @see AtlasTexture
+ */
+
+/**
+ * @fn public AtlasTexture TextureStitchEvent::getMap()
+ *
+ * Returns the \link AtlasTexture texture atlas\endlink of this event.
+ *
+ * @return The texture atlas
+ */
+
+/**
+ * @class net.minecraftforge.client.event.TextureStitchEvent.Pre
+ *
+ * Fired <b>before</b> the \ref AtlasTexture is stitched together.
+ * This can be used to add custom sprites to be stitched into the atlas.
+ *
+ * This event is not \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ *
+ * This event is fired on the \link FMLJavaModLoadingContext#getModEventBus() mod-specific event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ *
+ * @see ForgeHooksClient#onTextureStitchedPre(AtlasTexture, Set)
+ */
+
+    /**
+     * @fn public boolean Pre::addSprite(ResourceLocation sprite)
+     *
+     * Adds a sprite to be stitched into the texture atlas.
+     *
+     * @param sprite the location of the sprite
+     */
+
+/**
+ * @class net.minecraftforge.client.event.TextureStitchEvent.Post
+ *
+ * Fired <b>after</b> the \ref AtlasTexture is stitched together.
+ *
+ * This event is not \link Cancelable cancellable\endlink, and does not \link HasResult have a result\endlink.
+ *
+ * This event is fired on the \link FMLJavaModLoadingContext#getModEventBus() mod-specific event bus\endlink,
+ * only on the \link LogicalSide#CLIENT logical client\endlink.
+ *
+ * @see ForgeHooksClient#onTextureStitchedPost(AtlasTexture)
+ */


### PR DESCRIPTION
This PR adds documentation for the Forge client-only events, under `net.minecraftforge.client.event`.

Most of this will be taken from the [`event_docs` branch of my fork of MinecraftForge/MinecraftForge](https://github.com/sciwhiz12/MinecraftForge/tree/1.16/event_docs). Although that branch is based off an old version of Forge, most if not all of its contents can be transferred cleanly (though documentation for new events since that branch's last update will need to be written anew).

## Client events
### Screen-related events
 * [x] `GuiContainerEvent`
   * [x] `DrawForeground` _extends `GuiContainerEvent`_
   * [x] `DrawBackground` _extends `GuiContainerEvent`_
 * [x] `GuiOpenEvent`
 * [x] `GuiScreenEvent`
   * [x] `InitGuiEvent` _extends `GuiScreenEvent`_
      * [x] `Pre` _extends `InitGuiEvent`_
      * [x] `Post` _extends `InitGuiEvent`_
   * [x] `DrawScreenEvent` _extends `GuiScreenEvent`_
      * [x] `Pre` _extends `DrawScreenEvent`_
      * [x] `Post` _extends `DrawScreenEvent`_
   * [x] `BackgroundDrawnEvent` _extends `GuiScreenEvent`_
      * [x] `Pre` _extends `BackgroundDrawnEvent`_
      * [x] `Post` _extends `BackgroundDrawnEvent`_
   * [x] `PotionShiftEvent` _extends `GuiScreenEvent`_
   * [x] `MouseInputEvent` _extends `GuiScreenEvent`_
   * [x] `MouseClickedEvent` _extends `MouseInputEvent`_
      * [x] `Pre` _extends `MouseClickedEvent`_
      * [x] `Post` _extends `MouseClickedEvent`_
   * [x] `MouseReleasedEvent` _extends `MouseInputEvent`_
      * [x] `Pre` _extends `MouseReleasedEvent`_
      * [x] `Post` _extends `MouseReleasedEvent`_
   * [x] `MouseDragEvent` _extends `MouseInputEvent`_
      * [x] `Pre` _extends `MouseDragEvent`_
      * [x] `Post` _extends `MouseDragEvent`_
   * [x] `MouseScrollEvent` _extends `MouseInputEvent`_
      * [x] `Pre` _extends `MouseScrollEvent`_
      * [x] `Post` _extends `MouseScrollEvent`_
   * [x] `KeyboardKeyEvent` _extends `GuiScreenEvent`_
   * [x] `KeyboardKeyPressedEvent` _extends `KeyboardKeyEvent`_
      * [x] `Pre` _extends `KeyboardKeyPressedEvent`_
      * [x] `Post` _extends `KeyboardKeyPressedEvent`_
   * [x] `KeyboardKeyReleasedEvent` _extends `KeyboardKeyEvent`_
      * [x] `Pre` _extends `KeyboardKeyReleasedEvent`_
      * [x] `Post` _extends `KeyboardKeyReleasedEvent`_
   * [x] `KeyboardCharTypedEvent` _extends `GuiScreenEvent`_
      * [x] `Pre` _extends `KeyboardCharTypedEvent`_
      * [x] `Post` _extends `KeyboardCharTypedEvent`_

### Sound-related events
 * [ ] `PlaySoundEvent` _extends `SoundEvent`_
 * [ ] `PlaySoundSourceEvent` _extends `SourceSourceEvent`_
 * [ ] `PlayStreamingSourceEvent` _extends `SourceSourceEvent`_
 * [ ] `SoundEvent`
   * [ ] `SoundSourceEvent` _extends `SoundEvent`_
 * [ ] `SoundLoadEvent` _extends `SoundEvent`, implements `IModBusEvent`_
 * [ ] `SoundSetupEvent` _extends `SoundEvent`_

### Rendering events
 * [x] `DrawHighlightEvent`
   * [x] `HighlightBlock` _extends `DrawHighlightEvent`_
   * [x] `HighlightEntity` _extends `DrawHighlightEvent`_
 * [ ] `EntityViewRenderEvent`
   * [ ] `FogEvent` _extends `EntityViewRenderEvent`_
   * [ ] `FogDensity` _extends `FogEvent`_
   * [ ] `RenderFogEvent` _extends `FogEvent`_
   * [ ] `FogColors` _extends `FogEvent`_
   * [ ] `CameraSetup` _extends `EntityViewRenderEvent`_
   * [ ] `FOVModifier` _extends `EntityViewRenderEvent`_
 * [x] `FOVUpdateEvent`
 * [x] `RenderBlockOverlayEvent`
   * [x] **enum** `OverlayType`
 * [ ] `RenderGameOverlayEvent`
   * [ ] **enum** `ElementType`
   * [ ] `Pre` _extends `RenderGameOverlayEvent`_
   * [ ] `Post` _extends `RenderGameOverlayEvent`_
   * [ ] `BossInfo` _extends `Pre`_
   * [ ] `Text` _extends `Pre`_
   * [ ] `Chat` _extends `Pre`_
 * [x] `RenderHandEvent`
 * [x] `RenderItemInFrameEvent`
 * [x] `RenderLivingEvent`
   * [x] `Pre` _extends `RenderLivingEvent`_
   * [x] `Post` _extends `RenderLivingEvent`_
 * [x] `RenderNameplateEvent`
 * [x] `RenderPlayerEvent` _extends `PlayerEvent`_
   * [x] `Pre` _extends `RenderPlayerEvent`_
   * [x] `Post` _extends `RenderPlayerEvent`_
 * [x] `RenderTooltipEvent`
   * [x] `Pre` _extends `RenderTooltipEvent`_
   * [x] `Post` _extends `RenderTooltipEvent`_
   * [x] `PostBackground` _extends `Post`_
   * [x] `PostText` _extends `Post`_
   * [x] `Color` _extends `RenderTooltipEvent`_
 * [x] `RenderWorldLastEvent`

### Setup and registry events
 * [x] `ColorHandlerEvent` _implements `IModBusEvent`_
   * [x] `Block` _extends `ColorHandlerEvent`_
   * [x] `Item` _extends `ColorHandlerEvent`_
 * [x] `ModelBakeEvent` _implements `IModBusEvent`_
 * [x] `ModelRegistryEvent` _implements `IModBusEvent`_
 * [x] `ParticleFactoryRegisterEvent` _implements `IModBusEvent`_
 * [x] `RecipesUpdatedEvent`
 * [x] `TextureStitchEvent` _implements `IModBusEvent`_

### Misc. events
 * [x] `ClientChatEvent`
 * [x] `ClientChatReceivedEvent`
 * [x] `ClientPlayerNetworkEvent`
   * [x] `LoggedInEvent` _extends `ClientPlayerNetworkEvent`_
   * [x] `LoggedOutEvent` _extends `ClientPlayerNetworkEvent`_
   * [x] `RespawnEvent` _extends `ClientPlayerNetworkEvent`_
 * [ ] `ClientPlayerChangeGameModeEvent`
 * [x] `InputEvent`
   * [x] `RawMouseEvent` _extends `InputEvent`_
   * [x] `MouseInputEvent` _extends `InputEvent`_
   * [x] `MouseScrollEvent` _extends `InputEvent`_
   * [x] `KeyInputEvent` _extends `InputEvent`_
   * [x] `ClickInputEvent` _extends `InputEvent`_
 * [x] `InputUpdateEvent`
 * [ ] `ScreenshotEvent`